### PR TITLE
update doors to latest

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -231,15 +231,6 @@ doors.register("castle:jail_door", {
 		}
 })
 
-minetest.register_craft({
-	output = "castle:oak_door",
-	recipe = {
-		{"default:tree", "default:tree"},
-		{"default:tree", "default:tree"},
-		{"default:tree", "default:tree"}
-	}
-})
-
 function default.get_ironbound_chest_formspec(pos)
 	local spos = pos.x .. "," .. pos.y .. "," ..pos.z
 	local formspec =
@@ -260,7 +251,7 @@ minetest.register_node("castle:ironbound_chest",{
 	drawtype = "nodebox",
 	description = "Ironbound Chest",
 	tiles = {"castle_ironbound_chest_top.png",
-   "castle_ironbound_chest_top.png",
+	                  "castle_ironbound_chest_top.png",
 			"castle_ironbound_chest_side.png",
 			"castle_ironbound_chest_side.png",
 			"castle_ironbound_chest_back.png",

--- a/init.lua
+++ b/init.lua
@@ -15,7 +15,7 @@ minetest.register_node("castle:stonewall", {
 	paramtype = light,
 	drop = "castle:stonewall",
 	groups = {cracky=3},
-	
+
 })
 
 minetest.register_node("castle:rubble", {
@@ -54,11 +54,11 @@ minetest.register_node("castle:stonewall_corner", {
 	paramtype = light,
 	paramtype2 = "facedir",
 	description = "Castle Corner",
-	tiles = {"castle_stonewall.png", 
+	tiles = {"castle_stonewall.png",
 	                  "castle_stonewall.png",
-			"castle_corner_stonewall1.png", 
-			"castle_stonewall.png", 
-			"castle_stonewall.png", 
+			"castle_corner_stonewall1.png",
+			"castle_stonewall.png",
+			"castle_stonewall.png",
 			"castle_corner_stonewall2.png"},
 	groups = {cracky=3},
 })
@@ -121,13 +121,13 @@ minetest.register_craft( {
          }
 } )
 
-local mod_building_blocks = minetest.get_modpath("building_blocks") 
+local mod_building_blocks = minetest.get_modpath("building_blocks")
 local mod_streets = minetest.get_modpath("streets") or minetest.get_modpath("asphalt")
 
 if mod_building_blocks then
 	minetest.register_craft( {
          output = "castle:roofslate 4",
-         recipe = { 
+         recipe = {
 			{ "building_blocks:Tar" , "default:gravel" },
 			{ "default:gravel",       "building_blocks:Tar" }
 		}
@@ -135,7 +135,7 @@ if mod_building_blocks then
 
 	minetest.register_craft( {
          output = "castle:roofslate 4",
-         recipe = { 
+         recipe = {
 			{ "default:gravel",       "building_blocks:Tar" },
 			{ "building_blocks:Tar" , "default:gravel" }
 		}
@@ -145,7 +145,7 @@ end
 if mod_streets then
 		minetest.register_craft( {
          output = "castle:roofslate 4",
-         recipe = { 
+         recipe = {
 			{ "streets:asphalt" , "default:gravel" },
 			{ "default:gravel",   "streets:asphalt" }
 		}
@@ -153,7 +153,7 @@ if mod_streets then
 
 	minetest.register_craft( {
          output = "castle:roofslate 4",
-         recipe = { 
+         recipe = {
 			{ "default:gravel",   "streets:asphalt" },
 			{ "streets:asphalt" , "default:gravel" }
 		}
@@ -201,22 +201,34 @@ minetest.register_craft({
 	}
 })
 
-doors.register_door("castle:oak_door", {
-	description = "Oak Door",
-	inventory_image = "castle_oak_door_inv.png",
-	groups = {choppy=2,door=1},
-	tiles_bottom = {"castle_oak_door_bottom.png", "door_oak.png"},
-	tiles_top = {"castle_oak_door_top.png", "door_oak.png"},
-	only_placer_can_open = true,
+doors.register("castle:oak_door", {
+		tiles = {{ name = "castle_door_oak.png", backface_culling = true }},
+		description = "Oak Door",
+		inventory_image = "castle_oak_door_inv.png",
+		protected = true,
+		groups = { choppy = 2, door = 1 },
+		sounds = default.node_sound_wood_defaults(),
+		recipe = {
+			{"default:tree", "default:tree"},
+			{"default:tree", "default:tree"},
+			{"default:tree", "default:tree"},
+		}
 })
 
-doors.register_door("castle:jail_door", {
-	description = "Jail Door",
-	inventory_image = "castle_jail_door_inv.png",
-	groups = {cracky=2,door=1},
-	tiles_bottom = {"castle_jail_door_bottom.png", "door_jail.png"},
-	tiles_top = {"castle_jail_door_top.png", "door_jail.png"},
-	only_placer_can_open = true,
+doors.register("castle:jail_door", {
+		tiles = {{ name = "castle_door_jail.png", backface_culling = true }},
+		description = "Jail Door",
+		inventory_image = "castle_jail_door_inv.png",
+		protected = true,
+		groups = { cracky = 2, door = 1},
+		--sounds = default.node_sound_metal_defaults(),
+		sound_open = "doors_steel_door_open",
+		sound_close = "doors_steel_door_close",
+		recipe = {
+			{"castle:jailbars", "castle:jailbars"},
+			{"castle:jailbars", "castle:jailbars"},
+			{"castle:jailbars", "castle:jailbars"},
+		}
 })
 
 minetest.register_craft({
@@ -225,15 +237,6 @@ minetest.register_craft({
 		{"default:tree", "default:tree"},
 		{"default:tree", "default:tree"},
 		{"default:tree", "default:tree"}
-	}
-})
-
-minetest.register_craft({
-	output = "castle:jail_door",
-	recipe = {
-		{"castle:jailbars", "castle:jailbars"},
-		{"castle:jailbars", "castle:jailbars"},
-		{"castle:jailbars", "castle:jailbars"}
 	}
 })
 
@@ -257,7 +260,7 @@ minetest.register_node("castle:ironbound_chest",{
 	drawtype = "nodebox",
 	description = "Ironbound Chest",
 	tiles = {"castle_ironbound_chest_top.png",
-	                  "castle_ironbound_chest_top.png",
+   "castle_ironbound_chest_top.png",
 			"castle_ironbound_chest_side.png",
 			"castle_ironbound_chest_side.png",
 			"castle_ironbound_chest_back.png",
@@ -269,9 +272,9 @@ minetest.register_node("castle:ironbound_chest",{
 		type = "fixed",
 		fixed = {
 			{-0.500000,-0.500000,-0.312500,0.500000,-0.062500,0.312500},
-			{-0.500000,-0.062500,-0.250000,0.500000,0.000000,0.250000}, 
+			{-0.500000,-0.062500,-0.250000,0.500000,0.000000,0.250000},
 			{-0.500000,0.000000,-0.187500,0.500000,0.062500,0.187500},
-			{-0.500000,0.062500,-0.062500,0.500000,0.125000,0.062500}, 
+			{-0.500000,0.062500,-0.062500,0.500000,0.125000,0.062500},
 		},
 	},
 	selection_box = {
@@ -279,7 +282,7 @@ minetest.register_node("castle:ironbound_chest",{
 		fixed = {
 			{-0.5,-0.500000,-0.400000,0.5,0.200000,0.4},
 
-		},		
+		},
 	},
 	sounds = default.node_sound_wood_defaults(),
 	after_place_node = function(pos, placer)
@@ -388,7 +391,7 @@ minetest.register_craft({
 })
 
 if minetest.get_modpath("moreblocks") then
-	
+
 	stairsplus:register_all("castle", "dungeon_stone", "castle:dungeon_stone", {
 		description = "Dungeon Stone",
 		tiles = {"castle_dungeon_stone.png"},


### PR DESCRIPTION
Currently when you place a jail door it defaults to using the doors mod's steel_door texture;
this updates the jail and oak doors to use the latest doors mod's api and texture format
We also also need to fix the oak doorand  jail door/bar textures
![castle_door_jail](https://cloud.githubusercontent.com/assets/8119411/14099584/c929ee10-f554-11e5-8bfc-208963ce6cc1.png)
![castle_door_oak](https://cloud.githubusercontent.com/assets/8119411/14099585/c92ff134-f554-11e5-9c4e-86ac7f5e9fbd.png)
![castle_jail_door_inv](https://cloud.githubusercontent.com/assets/8119411/14099586/c941e0ba-f554-11e5-90ac-62ba39edfa0d.png)
![castle_jailbars](https://cloud.githubusercontent.com/assets/8119411/14099587/c942c228-f554-11e5-8e0c-78fae2e9189e.png)
![castle_jailbars_half](https://cloud.githubusercontent.com/assets/8119411/14099588/c942f19e-f554-11e5-866b-6d26627e9832.png)
